### PR TITLE
Refactor vMCP name resolution and enhance logging

### DIFF
--- a/backend/src/vmcp/core/services/oss_providers.py
+++ b/backend/src/vmcp/core/services/oss_providers.py
@@ -78,7 +78,7 @@ class DummyUserContext:
             if self.vmcp_name:
                 logger.info(f"🔍 DummyUserContext: Resolving vmcp_name '{self.vmcp_name}' to UUID for user '{user_id_int}'")
                 storage = StorageBase(user_id=user_id_int)
-                vmcp_id = storage.find_vmcp_name_in_private_registry(self.vmcp_name)
+                vmcp_id = storage.find_vmcp_name(self.vmcp_name)
                 if vmcp_id:
                     logger.info(f"✅ DummyUserContext: Resolved '{self.vmcp_name}' -> '{vmcp_id}'")
                 else:

--- a/backend/src/vmcp/storage/dummy_user.py
+++ b/backend/src/vmcp/storage/dummy_user.py
@@ -98,7 +98,7 @@ class UserContext:
             if self.vmcp_name and self.vmcp_name != "vmcp" and self.vmcp_name != "unknown":
                 # Create storage instance to find the actual vmcp_id
                 storage = StorageBase(user_id=self.user_id)
-                vmcp_id = storage.find_vmcp_name_in_private_registry(self.vmcp_name)
+                vmcp_id = storage.find_vmcp_name(self.vmcp_name)
                 if vmcp_id:
                     self.vmcp_config_manager = VMCPConfigManager(self.user_id, vmcp_id)
                     logger.info(f"VMCP Config manager set: {vmcp_id}")


### PR DESCRIPTION
- Updated `find_vmcp_name_in_private_registry` to `find_vmcp_name` in `StorageBase` for improved clarity and functionality, allowing searches in both private and public registries.
- Enhanced logging in `StorageBase` to include user ID in debug messages for better traceability.
- Adjusted `DummyUserContext` and `UserContext` to reflect the new method name for vMCP ID resolution.
- Improved metadata handling in `install_vmcp_from_remote` to ensure URLs are correctly regenerated for both saving and response.